### PR TITLE
Fix PDNC commands and prevent usage by non-admins

### DIFF
--- a/pdnc.lua
+++ b/pdnc.lua
@@ -26,15 +26,9 @@ global.pdnc_min_per_day = 0.1
 
 function pdnc_setup()
 	--game.surfaces[global.pdnc_surface].ticks_per_day = pdnc_min_to_ticks(10.0)
-	pdnc_on_load()
 	doomsday_setup()
 end
 
-function pdnc_on_load()
-	commands.add_command("pdnc", "gives PDNC's status", pdnc_print_status)
-	commands.add_command("pdnc_toggle", "toggles pdnc", pdnc_toggle)
-	commands.add_command("pdnc_toggle_debug", "toggles pdnc debug mode", pdnc_toggle_debug)
-	commands.add_command("pdnc_disable_and_reset", "Disabled pdnc and resets the dnc to the vanilla default", pdnc_disable_and_reset)
 end
 
 function pdnc_toggle_debug()
@@ -274,10 +268,16 @@ PDNC_init.on_nth_ticks = {
 	[global.pdnc_stepsize] = pdnc_core,
 }
 
+PDNC_init.add_commands = function()
+	commands.add_command("pdnc", "gives PDNC's status", pdnc_print_status)
+	commands.add_command("pdnc_toggle", "toggles pdnc", pdnc_toggle)
+	commands.add_command("pdnc_toggle_debug", "toggles pdnc debug mode", pdnc_toggle_debug)
+	commands.add_command("pdnc_disable_and_reset", "Disabled pdnc and resets the dnc to the vanilla default", pdnc_disable_and_reset)
+end
+
 PDNC_init.on_init = function() -- this runs when Event.core_events.init
 	log("PDNC init")
 	--put stuff here
-	pdnc_on_load()
 	global.PDNC_data = global.PDNC_data or script_data  -- NO TOUCHY
 
 end
@@ -295,6 +295,3 @@ PDNC_init.get_events = function()
 end
 
 return PDNC_init
-
---script.on_load(pdnc_on_load())
--- on init and on load, run: pdnc_on_load() doomsday_on_load()

--- a/pdnc.lua
+++ b/pdnc.lua
@@ -29,30 +29,41 @@ function pdnc_setup()
 	doomsday_setup()
 end
 
+-- Returns true if the player is an admin
+function check_admin(ctx)
+	local player = game.players[ctx.player_index]
+	if not player.admin then
+		player.print("Only admins can use /"..ctx.name)
+		return false
+	end
+	return true
 end
 
-function pdnc_toggle_debug()
+function pdnc_toggle_debug(ctx)
+	if not check_admin(ctx) then return end
 	global.pdnc_debug = not global.pdnc_debug
-	pdnc_print_status()
+	pdnc_print_status(ctx)
 end
 
-function pdnc_toggle()
+function pdnc_toggle(ctx)
+	if not check_admin(ctx) then return end
 	global.pdnc_enabled = not global.pdnc_enabled
-	pdnc_print_status()
+	pdnc_print_status(ctx)
 end
 
-function pdnc_print_status()
+function pdnc_print_status(ctx)
+	local player = game.players[ctx.player_index]
 	if(global.pdnc_enabled)then
-		game.print("PDNC is enabled")
+		player.print("PDNC is enabled")
 	else
-		game.print("PDNC is disabled")
+		player.print("PDNC is disabled")
 	end
 	
 	if(global.pdnc_debug)then
-		game.print("PDNC debug is enabled")
+		player.print("PDNC debug is enabled")
 		pdnc_extended_status()
 	else
-		game.print("PDNC debug is disabled")
+		player.print("PDNC debug is disabled")
 	end
 end
 
@@ -133,7 +144,8 @@ function pdnc_cleanup_last_tick(current_surface)
 	current_surface.morning = 999999999998
 end
 
-function pdnc_disable_and_reset()
+function pdnc_disable_and_reset(ctx)
+	if not check_admin(ctx) then return end
 	local current_surface = game.surfaces[global.pdnc_surface]
 	pdnc_cleanup_last_tick(current_surface)
 	-- DO NOT CHANGE THIS ORDER! 


### PR DESCRIPTION
Move the add_command calls to the add_commands hook and check if the player is admin before running them.