### PR TITLE
Restrict debug panels to admins

### DIFF
--- a/doomsday.lua
+++ b/doomsday.lua
@@ -56,15 +56,9 @@ function doomsday_toggle()
 end
 
 function doomsday_setup()
-	doomsday_on_load()
 	if global.doomsday_use_different_spawn then
 		doomsday_activate_different_spawn()
 	end
-end
-
-function doomsday_on_load()
-	-- commands.add_command("timeleft", "Gives you the time till doomsday!", doomsday_time_left)
-	-- commands.add_command("doomsday", "Prints doomsday status", doomsday_status)
 end
 
 function doomsday_early_death()
@@ -244,7 +238,6 @@ end
 doomsday_init.on_load = function() -- this runs when Event.core_events.load
 	log("doomsday load")
 	--put stuff here
-	doomsday_on_load()
 	script_data = global.doomsday_data or script_data  -- NO TOUCHY
 end
 
@@ -256,4 +249,3 @@ return doomsday_init
 
 --Event.register(-global.pdnc_stepsize, doomsday_pdnc_program) --intentionally using the PDNC stepsize so the functions sync this can be skipped, since it's called from pdnc!
 --Event.register(Event.core_events.init, doomsday_setup)
---Event.register(Event.core_events.load, doomsday_on_load)

--- a/gui.lua
+++ b/gui.lua
@@ -42,7 +42,12 @@ end
 local function get_sprite_button_DOOM(player)
 	local button_flow = mod_gui.get_button_flow(player)
 	button_DOOM = button_flow.doomsday_stats_button
-	if not button then
+
+	if button_DOOM then
+		button_DOOM.destroy()
+	end
+
+	if player.admin then
 		button_DOOM = button_flow.add{
 			type = "sprite-button",
 			name = "doomsday_stats_button",
@@ -95,7 +100,12 @@ end
 local function get_sprite_button_PDNC(player)
 	local button_flow = mod_gui.get_button_flow(player)
 	local button_PDNC = button_flow.PDNC_stats_button
-	if not button then
+
+	if button_PDNC then
+		button_PDNC.destroy()
+	end
+
+	if player.admin then
 		button_PDNC = button_flow.add{
 			type = "sprite-button",
 			name = "PDNC_stats_button",
@@ -146,6 +156,32 @@ local function toggle_frame_counter(player)
 	gui_update_counter(player)
 end
 
+local function update_buttons(event)
+	local player = game.players[event.player_index]
+	if not (player and player.valid) then
+		return
+	end
+
+	get_sprite_button_DOOM(player)
+	get_sprite_button_PDNC(player)
+
+	-- Make sure the frames are not visible to players
+	if not player.admin then
+		local gui = mod_gui.get_frame_flow(player)
+		local frame_PDNC = gui.PDNC_stats
+		
+		if frame_PDNC then
+			frame_PDNC.destroy()
+		end
+
+		local frame_DOOM = gui.doomsday_stats
+		
+		if frame_DOOM then
+			frame_DOOM.destroy()
+		end
+	end
+end
+
 -- ON GUI CLICK AND OTHERS
 local function on_gui_click(event)
 	local gui = event.element
@@ -168,8 +204,7 @@ local function on_player_created(event)
 		return
 	end
 	
-	get_sprite_button_DOOM(player)
-	get_sprite_button_PDNC(player)
+	update_buttons(event)
 	toggle_frame_counter(player)
 end
 
@@ -198,6 +233,8 @@ local script_events = {
 	--put stuff here
 	[defines.events.on_gui_click] = on_gui_click,
 	[defines.events.on_player_created] = on_player_created,
+	[defines.events.on_player_promoted] = update_buttons,
+	[defines.events.on_player_demoted] = update_buttons,
 }
 
 doomsdaygui_init.on_nth_ticks = {


### PR DESCRIPTION
Adds a check for player.admin to the debug panels buttons and frames.  Also removed the unused doomsday_on_load function.